### PR TITLE
fix: delayJS incorrect script count may no longer be correct since recent markup changes in WP Rocket

### DIFF
--- a/lib/wprDetection.util.ts
+++ b/lib/wprDetection.util.ts
@@ -118,7 +118,7 @@ export function checkDelayJS({
         delayjs.version = extractVersion(script.textContent) ?? null;
       }
     }
-    if ('rocketlazyloadscript' === script.getAttribute('type')) {
+    if (script.getAttribute('type')?.includes('rocketlazyloadscript')) {
       delayjs.present = true;
       s.delayed = true;
       if (script.hasAttribute(DELAYJS_SRC)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wpr-front-debugging-tool",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wpr-front-debugging-tool",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {


### PR DESCRIPTION
# Description
Updated the DelayJS detection script.
Fixes #4 

## Type of change

- [ ] New feature (non-breaking change which adds functionality).
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] Enhancement (non-breaking change which improves an existing functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as before).
- [ ] Sub-task of #(issue number)
- [ ] Chore
- [ ] Release


